### PR TITLE
Mach is deprecated, update to mach2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,10 +9,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
-name = "mach"
-version = "0.3.2"
+name = "mach2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
 dependencies = [
  "libc",
 ]
@@ -22,7 +22,7 @@ name = "slice-ring-buffer"
 version = "0.3.2"
 dependencies = [
  "libc",
- "mach",
+ "mach2",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ edition = "2018"
 [badges]
 maintenance = { status = "passively-maintained" }
 
-[target.'cfg(all(any(target_os = "macos", target_os = "ios"), not(feature = "unix_sysv")))'.dependencies.mach]
-version = "0.3"
+[target.'cfg(all(any(target_os = "macos", target_os = "ios"), not(feature = "unix_sysv")))'.dependencies.mach2]
+version = "0.4.1"
 default-features = false
 
 [target.'cfg(target_os = "windows")'.dependencies.winapi]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
 max_width = 79
-fn_args_layout = "Compressed"
+fn_params_layout = "Compressed"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ extern crate core;
     any(target_os = "macos", target_os = "ios"),
     not(feature = "unix_sysv")
 ))]
-extern crate mach2;
+extern crate mach2 as mach;
 
 #[cfg(unix)]
 extern crate libc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ extern crate core;
     any(target_os = "macos", target_os = "ios"),
     not(feature = "unix_sysv")
 ))]
-extern crate mach;
+extern crate mach2;
 
 #[cfg(unix)]
 extern crate libc;

--- a/src/mirrored/macos.rs
+++ b/src/mirrored/macos.rs
@@ -4,7 +4,7 @@
 
 use super::mem;
 
-use mach;
+use mach2 as mach;
 use mach::boolean::boolean_t;
 use mach::kern_return::*;
 use mach::mach_types::mem_entry_name_port_t;

--- a/src/mirrored/macos.rs
+++ b/src/mirrored/macos.rs
@@ -4,7 +4,6 @@
 
 use super::mem;
 
-use mach2 as mach;
 use mach::boolean::boolean_t;
 use mach::kern_return::*;
 use mach::mach_types::mem_entry_name_port_t;
@@ -20,6 +19,7 @@ use mach::vm_inherit::VM_INHERIT_NONE;
 use mach::vm_prot::{vm_prot_t, VM_PROT_READ, VM_PROT_WRITE};
 use mach::vm_statistics::{VM_FLAGS_ANYWHERE, VM_FLAGS_FIXED};
 use mach::vm_types::mach_vm_address_t;
+use mach2 as mach;
 
 use super::AllocError;
 


### PR DESCRIPTION
Using cargo deny, I found that 'mach' is unmaintained. I suggest using 'mach2,' a fork that is maintained, instead of 'mach'. https://github.com/fitzgen/mach/issues/63#issuecomment-1067100562



```rs
error[unmaintained]: mach is unmaintained
  ┌─ /slice_ring_buffer/Cargo.lock:2:1
  │
2 │ mach 0.3.2 registry+https://github.com/rust-lang/crates.io-index
  │ ---------------------------------------------------------------- unmaintained advisory detected
  │
  = ID: RUSTSEC-2020-0168
  = Advisory: https://rustsec.org/advisories/RUSTSEC-2020-0168
  = Last release was almost 4 years ago.
    
    Maintainer(s) seem to be completely unreachable. 
    
    ## Possible Alternative(s)
    
    These may or may not be suitable alternatives and have not been vetted in any way;
    - [mach2](https://crates.io/crates/mach2) - direct fork
  = Announcement: https://github.com/fitzgen/mach/issues/63
  = Solution: No safe upgrade is available!
  = mach v0.3.2
    └── slice-ring-buffer v0.3.2

advisories FAILED, bans ok, licenses ok, sources ok
``` is unmaintained,